### PR TITLE
Add TRU Wolfpack branding to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,10 @@
   }
   *{box-sizing:border-box;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
   body{margin:0;background:var(--bg);color:var(--text)}
-  header{position:sticky;top:0;z-index:40;background:linear-gradient(180deg,var(--accent),#f36f00);color:#fff;padding:14px 16px;font-weight:900;font-size:18px}
+  header{position:sticky;top:0;z-index:40;background:linear-gradient(180deg,var(--accent),#f36f00);color:#fff;padding:12px 16px}
+  .header-content{display:flex;align-items:center;gap:16px;font-weight:900;font-size:18px}
+  .header-content svg{height:64px;width:auto;flex:none}
+  .header-text{line-height:1.2}
   .container{max-width:1320px;margin:20px auto;padding:0 16px;display:grid;gap:16px;grid-template-columns:1fr 1fr}
   .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:14px}
   h1{margin:0 0 8px;font-size:18px;color:#000}
@@ -55,7 +58,26 @@
 </style>
 </head>
 <body>
-<header>WolfPack Volleyball — Team Logger, Rotation, Events & Dashboards</header>
+<header>
+  <div class="header-content">
+    <svg class="logo" viewBox="0 0 260 150" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+      <defs>
+        <linearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stop-color="#ff7f11" />
+          <stop offset="100%" stop-color="#ff5500" />
+        </linearGradient>
+      </defs>
+      <g fill="url(#grad)" stroke="none">
+        <path d="M46 118c12-34 44-58 86-58 24 0 42 8 54 16l18-16 10 30-16 10 14 12-12 28-40 18H80z" opacity="0.94" />
+        <path d="M128 122c6-18 26-32 52-32 14 0 24 6 30 10l12-10 8 24-12 8 10 10-10 22-30 14h-52z" opacity="0.88" />
+        <path d="M108 132c12-16 34-30 58-30 26 0 40 10 46 16-14 4-26 14-32 26-18 6-40 10-66-12z" opacity="0.76" />
+        <text x="130" y="48" text-anchor="middle" font-size="46" font-family="'Impact','Anton','Arial Black',sans-serif" letter-spacing="2">TRU</text>
+        <text x="130" y="92" text-anchor="middle" font-size="46" font-family="'Impact','Anton','Arial Black',sans-serif" letter-spacing="1">WOLFPACK</text>
+      </g>
+    </svg>
+    <div class="header-text">WolfPack Volleyball — Team Logger, Rotation, Events &amp; Dashboards</div>
+  </div>
+</header>
 
 <div class="container">
   <!-- LEFT: TEAM SIDE -->


### PR DESCRIPTION
## Summary
- replace the plain header text with a flexible layout that can host the team branding
- add an inline SVG treatment that mirrors the TRU Wolfpack logo with gradient text and wolf silhouettes

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68d5050073d88325b54add26daa508ac